### PR TITLE
Provide PNG icons, correct appdata

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,11 @@
+--- e-juice-calc-1.0.5/packaging/com.szibele.e-juice-calc.appdata.xml~	2019-01-03 22:49:17.682858975 +0000
++++ e-juice-calc-1.0.5/packaging/com.szibele.e-juice-calc.appdata.xml	2019-01-03 22:49:23.970904703 +0000
+@@ -13,7 +13,7 @@
+         </p>
+     </description>
+     <content_rating type="oars-1.1" />
+-    <launchable type="desktop-id">com.szibele.e-juice-calc</launchable>
++    <launchable type="desktop-id">com.szibele.e-juice-calc.desktop</launchable>
+     <screenshots>
+         <screenshot type="default">
+             <caption>The main E-Juice-Calc window</caption>

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -1153,7 +1153,11 @@
                 "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/metainfo/",
                 "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/appdata/",
                 "cp packaging/com.szibele.e-juice-calc.desktop /app/share/applications/",
-                "cp res/icon2.svg /app/share/icons/hicolor/scalable/apps/com.szibele.e-juice-calc.svg"
+                "cp res/icon2.svg /app/share/icons/hicolor/scalable/apps/com.szibele.e-juice-calc.svg",
+                "for size in 16 24 32 48 64 128 256 512; do
+                    rsvg-convert -w $size -h $size -f png -o $size.png res/icon2.svg
+                    install -Dm644 $size.png /app/share/icons/hicolor/${size}x${size}/apps/com.szibele.e-juice-calc.png
+                done"
             ],
             "buildsystem": "simple",
             "cleanup": [],

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -1151,7 +1151,6 @@
                 "cp -r res/* /app/share/e-juice-calc/res/",
                 "mkdir -p /app/share/metainfo /app/share/appdata /app/share/applications /app/share/icons/hicolor/scalable/apps",
                 "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/metainfo/",
-                "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/appdata/",
                 "cp packaging/com.szibele.e-juice-calc.desktop /app/share/applications/",
                 "cp res/icon2.svg /app/share/icons/hicolor/scalable/apps/com.szibele.e-juice-calc.svg",
                 "for size in 16 24 32 48 64 128 256 512; do
@@ -1168,6 +1167,10 @@
                     "sha256": "a678ddda81eded804313d7f6a4ffdea10019b72ecdde37844b385c8dcaecdb7d",
                     "type": "archive",
                     "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.5/e-juice-calc-1.0.5.tar.gz"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
Fix https://github.com/flathub/com.szibele.e-juice-calc/issues/1 by exporting PNG icons and correctly linking the appdata to the desktop file.